### PR TITLE
Fix order status persistence and sync with Supabase cache

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -177,11 +177,22 @@ function App() {
     setOrders((prev) => [...prev, data]);
   };
 
-  const handleUpdateOrderStatus = async (orderId: string, status: Order['estado']) => {
-    await dataService.updateOrderStatus(orderId, status);
-    setOrders(
-      orders.map(order => (order.id === orderId ? { ...order, estado: status } : order))
-    );
+  const handleUpdateOrderStatus = async (targetOrder: Order, status: Order['estado']) => {
+    try {
+      const updatedOrder = await dataService.updateOrderStatus(targetOrder, status);
+      setOrders((prevOrders) => {
+        const index = prevOrders.findIndex(order => order.id === updatedOrder.id);
+        if (index === -1) {
+          return prevOrders;
+        }
+        const next = [...prevOrders];
+        next[index] = updatedOrder;
+        return next;
+      });
+    } catch (error) {
+      console.error('Error actualizando el estado del pedido:', error);
+      alert('No se pudo actualizar el estado del pedido. Inténtalo nuevamente.');
+    }
   };
 
   const handleAddCustomer = async (newCustomer: Customer) => {

--- a/src/components/Cocina.tsx
+++ b/src/components/Cocina.tsx
@@ -6,7 +6,7 @@ import { formatDateTime } from '../utils/format';
 
 interface CocinaProps {
   orders: Order[];
-  onUpdateOrderStatus: (orderId: string, status: Order['estado']) => void;
+  onUpdateOrderStatus: (order: Order, status: Order['estado']) => void;
 }
 
 export function Cocina({ orders, onUpdateOrderStatus }: CocinaProps) {
@@ -111,7 +111,7 @@ export function Cocina({ orders, onUpdateOrderStatus }: CocinaProps) {
                       <div className="space-y-2">
                         {order.estado === 'pendiente' && (
                           <button
-                            onClick={() => onUpdateOrderStatus(order.id, 'preparando')}
+                            onClick={() => onUpdateOrderStatus(order, 'preparando')}
                             className="w-full py-2 rounded-lg text-white font-medium transition-all duration-200 hover:scale-105 text-sm"
                             style={{ backgroundColor: COLORS.dark }}
                           >
@@ -120,7 +120,7 @@ export function Cocina({ orders, onUpdateOrderStatus }: CocinaProps) {
                         )}
                         {order.estado === 'preparando' && (
                           <button
-                            onClick={() => onUpdateOrderStatus(order.id, 'listo')}
+                            onClick={() => onUpdateOrderStatus(order, 'listo')}
                             className="w-full py-2 rounded-lg font-medium transition-all duration-200 hover:scale-105 text-sm"
                             style={{ backgroundColor: COLORS.accent, color: COLORS.dark }}
                           >

--- a/src/components/Comandas.tsx
+++ b/src/components/Comandas.tsx
@@ -7,7 +7,7 @@ import dataService from '../lib/dataService';
 
 interface ComandasProps {
   orders: Order[];
-  onUpdateOrderStatus: (orderId: string, status: Order['estado']) => void;
+  onUpdateOrderStatus: (order: Order, status: Order['estado']) => void;
 }
 
 interface EditingOrder {
@@ -365,7 +365,7 @@ export function Comandas({ orders, onUpdateOrderStatus }: ComandasProps) {
                     <div className="space-y-2">
                       {order.estado === 'pendiente' && (
                         <button
-                          onClick={() => onUpdateOrderStatus(order.id, 'preparando')}
+                          onClick={() => onUpdateOrderStatus(order, 'preparando')}
                           className="w-full py-2 rounded-lg text-white font-medium transition-all duration-200 hover:scale-105 text-sm"
                           style={{ backgroundColor: COLORS.dark }}
                         >
@@ -374,7 +374,7 @@ export function Comandas({ orders, onUpdateOrderStatus }: ComandasProps) {
                       )}
                       {order.estado === 'preparando' && (
                         <button
-                          onClick={() => onUpdateOrderStatus(order.id, 'listo')}
+                          onClick={() => onUpdateOrderStatus(order, 'listo')}
                           className="w-full py-2 rounded-lg text-white font-medium transition-all duration-200 hover:scale-105 text-sm"
                           style={{ backgroundColor: COLORS.accent, color: COLORS.dark }}
                         >
@@ -391,7 +391,7 @@ export function Comandas({ orders, onUpdateOrderStatus }: ComandasProps) {
                             Modificar pedido
                           </button>
                           <button
-                            onClick={() => onUpdateOrderStatus(order.id, 'entregado')}
+                            onClick={() => onUpdateOrderStatus(order, 'entregado')}
                             className="w-full py-2 bg-green-600 text-white rounded-lg font-medium transition-all duration-200 hover:scale-105 text-sm"
                           >
                             Entregar pedido


### PR DESCRIPTION
## Summary
- pass complete order objects when changing statuses from Comandas and Cocina so the handler has full context
- update the order status handler to surface failures and refresh local state from the updated record
- enhance the data service to share the Supabase select, keep the local cache in sync, and return the updated order after status changes

## Testing
- npm run build
- npm run lint *(fails: Invalid option '--ext' when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ce117438dc8324a2c8d56cb79fa1ab