### PR TITLE
Remove Supabase auth session handling

### DIFF
--- a/src/lib/dataService.ts
+++ b/src/lib/dataService.ts
@@ -1,5 +1,5 @@
 import { MenuItem, Order, Customer, Empleado, Gasto, BalanceResumen, PaymentMethod, CartItem } from '../types';
-import { supabase, ensureSupabaseSession } from './supabaseClient';
+import { supabase } from './supabaseClient';
 import { getLocalData, setLocalData } from '../data/localData';
 import { slugify, generateMenuItemCode } from '../utils/strings';
 
@@ -12,8 +12,7 @@ const ensureSupabaseReady = async (): Promise<boolean> => {
   if (!isSupabaseAvailable()) {
     return false;
   }
-  const session = await ensureSupabaseSession();
-  return !!session;
+  return true;
 };
 
 const PAYMENT_METHODS: PaymentMethod[] = ['efectivo', 'tarjeta', 'nequi'];

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,67 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
-import type { Session } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
-
-let establishingSession: Promise<Session | null> | null = null;
-let hasLoggedMissingSession = false;
-
-const createSupabaseSession = async (): Promise<Session | null> => {
-  try {
-    const serviceEmail = import.meta.env.VITE_SUPABASE_SERVICE_EMAIL;
-    const servicePassword = import.meta.env.VITE_SUPABASE_SERVICE_PASSWORD;
-
-    if (serviceEmail && servicePassword) {
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email: serviceEmail,
-        password: servicePassword,
-      });
-      if (error) throw error;
-      return data.session ?? null;
-    }
-
-    const { data, error } = await supabase.auth.signInAnonymously();
-    if (error) throw error;
-    return data.session ?? null;
-  } catch (error) {
-    console.warn('[supabaseClient] No se pudo establecer una sesión con Supabase.', error);
-    return null;
-  }
-};
-
-export const ensureSupabaseSession = async (): Promise<Session | null> => {
-  if (!supabaseUrl || !supabaseKey) {
-    return null;
-  }
-
-  const { data } = await supabase.auth.getSession();
-  if (data.session) {
-    hasLoggedMissingSession = false;
-    return data.session;
-  }
-
-  if (!establishingSession) {
-    establishingSession = (async () => {
-      try {
-        return await createSupabaseSession();
-      } finally {
-        establishingSession = null;
-      }
-    })();
-  }
-
-  const session = await establishingSession;
-  if (session) {
-    hasLoggedMissingSession = false;
-    return session;
-  }
-
-  if (!hasLoggedMissingSession) {
-    hasLoggedMissingSession = true;
-    console.warn('[supabaseClient] No hay sesión activa de Supabase.');
-  }
-  return null;
-};


### PR DESCRIPTION
## Summary
- remove the Supabase session-establishing code so the client no longer calls auth helpers
- simplify the data service readiness check to rely on environment configuration instead of Supabase auth

## Testing
- npm run lint *(fails: Invalid option '--ext' - this script is incompatible with eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d092676a7c8324856df0c1572ffe6e