### PR TITLE
Ensure order edits update totals before delivery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import { Empleados } from './components/Empleados';
 import { Gastos } from './components/Gastos';
 import { Login } from './components/Login';
 import { Navigation } from './components/Navigation';
-import { ModuleType, User, MenuItem, Order, Customer } from './types';
+import { ModuleType, User, MenuItem, Order, Customer, CartItem } from './types';
 import { initializeLocalData } from './data/localData';
 import dataService from './lib/dataService';
 
@@ -195,6 +195,29 @@ function App() {
     }
   };
 
+  const handleSaveOrderChanges = async (
+    orderId: string,
+    updates: { items: CartItem[]; total: number }
+  ) => {
+    try {
+      await dataService.updateOrder(orderId, updates);
+      setOrders((prevOrders) =>
+        prevOrders.map((order) =>
+          order.id === orderId
+            ? {
+                ...order,
+                items: updates.items,
+                total: updates.total,
+              }
+            : order
+        )
+      );
+    } catch (error) {
+      console.error('Error actualizando la orden:', error);
+      throw error;
+    }
+  };
+
   const handleAddCustomer = async (newCustomer: Customer) => {
     const data = await dataService.createCustomer(newCustomer);
     setCustomers([...customers, data]);
@@ -246,6 +269,7 @@ function App() {
           <Comandas
             orders={orders}
             onUpdateOrderStatus={handleUpdateOrderStatus}
+            onSaveOrderChanges={handleSaveOrderChanges}
           />
         )}
         {module === 'inventario' && (

--- a/src/components/Comandas.tsx
+++ b/src/components/Comandas.tsx
@@ -8,6 +8,7 @@ import dataService from '../lib/dataService';
 interface ComandasProps {
   orders: Order[];
   onUpdateOrderStatus: (order: Order, status: Order['estado']) => void;
+  onSaveOrderChanges: (orderId: string, updates: { items: CartItem[]; total: number }) => Promise<void>;
 }
 
 interface EditingOrder {
@@ -16,7 +17,7 @@ interface EditingOrder {
   total: number;
 }
 
-export function Comandas({ orders, onUpdateOrderStatus }: ComandasProps) {
+export function Comandas({ orders, onUpdateOrderStatus, onSaveOrderChanges }: ComandasProps) {
   const [menuItems, setMenuItems] = useState<MenuItem[]>([]);
   const [editingOrder, setEditingOrder] = useState<EditingOrder | null>(null);
   const [showAddProduct, setShowAddProduct] = useState(false);
@@ -163,22 +164,14 @@ export function Comandas({ orders, onUpdateOrderStatus }: ComandasProps) {
     if (!editingOrder) return;
     
     try {
-      // Actualizar la orden en la base de datos con los nuevos items y total
-      await dataService.updateOrder(editingOrder.orderId, {
+      await onSaveOrderChanges(editingOrder.orderId, {
         items: editingOrder.items,
         total: editingOrder.total
       });
-      
-      // Actualizar el estado local
-      const updatedOrders = orders.map(order => 
-        order.id === editingOrder.orderId 
-          ? { ...order, items: editingOrder.items, total: editingOrder.total }
-          : order
-      );
-      
+
       setEditingOrder(null);
-      // Aquí deberías llamar a una función para actualizar las órdenes en el componente padre
-      window.location.reload(); // Temporal - idealmente deberías usar un callback
+      setShowAddProduct(false);
+      setSearchQuery('');
     } catch (error) {
       console.error('Error updating order:', error);
       alert('Error al actualizar la orden');


### PR DESCRIPTION
## Summary
- add an App-level handler to persist edited orders and refresh them in state
- pass the handler into Comandas so saving updates totals without reloading
- clear temporary edit state after saving so the UI reflects the new order data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d099c0122c832490c69b8f0a3c88b7